### PR TITLE
Don't make changes if the view was destroyed

### DIFF
--- a/addon/mixins/suggest.js
+++ b/addon/mixins/suggest.js
@@ -32,6 +32,7 @@ export default Ember.Mixin.create({
 
     var _scope = this;
     var func = function(){
+      if( _scope.isDestroyed ) return;
       _scope.set('suggestStyles', 'display:none;');
       if(!_scope.get('selectedFromList')){
         _scope.set('selectedVal', '');


### PR DESCRIPTION
As this function is executed 200 ms after the running, the application could have changed to another url/view and the suggest component may have being deleted, causing an exception like: Uncaught Error: Assertion Failed: calling set on destroyed object.
This should prevent it.
