### PR TITLE
Moving the action to the item-root-tag

### DIFF
--- a/blueprints/suggest/files/app/templates/components/__name__.hbs
+++ b/blueprints/suggest/files/app/templates/components/__name__.hbs
@@ -3,8 +3,8 @@
   <div class="tt-dataset-states">
     <span class="tt-suggestions" style="display: block;">
       {{#each result in suggestions}}
-        <div class="tt-suggestion">
-          <p style="white-space: normal;" {{action 'selectItem' result }}>{{result.display}}</p>
+        <div class="tt-suggestion" {{action 'selectItem' result }}>
+          <p style="white-space: normal;">{{result.display}}</p>
         </div>
       {{/each}}
     </span>


### PR DESCRIPTION
Moving the action to the item-root-tag allows you to click safely in a result without cancelling the suggestions when clicking on empty space caused by default margins styles on the <p> elements.
